### PR TITLE
Hardcode file locations of moveit_servo for micro-ROS_moveit2_demo

### DIFF
--- a/src/microros_moveit2servo_demo.cpp
+++ b/src/microros_moveit2servo_demo.cpp
@@ -44,8 +44,10 @@
 #include <std_msgs/msg/empty.hpp>
 
 // Servo
-#include <moveit_servo/servo_parameters.cpp>
-#include <moveit_servo/servo.h>
+//#include <moveit_servo/servo_parameters.cpp>
+#include </home/ubu/ws_moveit2/src/moveit2/moveit_ros/moveit_servo/src/servo_parameters.cpp>
+//#include <moveit_servo/servo.h>
+#include </home/ubu/ws_moveit2/src/moveit2/moveit_ros/moveit_servo/include/moveit_servo/servo.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 
 using namespace std::chrono_literals;


### PR DESCRIPTION
Following instructions from
https://github.com/micro-ROS/micro-ROS_moveit2_demo

looks like the "find_package(moveit_servo REQUIRED)" in the CMAKE file is not finding the package.
I hard coded the moveit_servo file locations per my installation to make further progress but blocked by
issue:
"Given an error when colcon build microros_moveit2_demo #4"

Creating pull request per @pablogs9 